### PR TITLE
Add Command Line Options

### DIFF
--- a/bin/dropbox-deployment
+++ b/bin/dropbox-deployment
@@ -1,6 +1,31 @@
 #!/usr/bin/env ruby
 
 require 'dropbox-deployment'
+require 'optparse'
+
+options = {}
+optparse = OptionParser.new do |opts|
+  options["debug"] = false
+
+  opts.on("-d", "--debug", "Turn on debugging") do |debug|
+    options["debug"] = true
+  end
+
+  opts.on("-u", "--upload-path DROPBOX_PATH", "The path to the folder on Dropbox") do |dropbox_path|
+    options["dropbox_path"] = dropbox_path
+  end
+
+  opts.on("-a", "--artifacts-path ARTIFACTS_PATH", "Local file or directory to upload to Dropbox") do |artifacts_path|
+    options["artifacts_path"] = artifacts_path
+  end
+
+  opts.on("-h", "--help", "Display this screen") do
+    puts opts
+    exit
+  end
+end
+
+optparse.parse!
 
 deployer = DropboxDeployment::Deployer.new
-deployer.deploy
+deployer.deploy(options)

--- a/lib/dropbox-deployment.rb
+++ b/lib/dropbox-deployment.rb
@@ -47,7 +47,6 @@ module DropboxDeployment
         exit(1)
       end
       config = YAML.load_file('dropbox-deployment.yml')
-      testing = false
       unless config.has_key?('deploy')
         puts "\nError in config file! Build file must contain a `deploy` object.\n\n"
         exit(1)

--- a/lib/dropbox-deployment.rb
+++ b/lib/dropbox-deployment.rb
@@ -17,9 +17,10 @@ module DropboxDeployment
 
     def upload_file(dropbox_client, file, dropbox_path)
       file_name = File.basename(file)
-      content = IO.read(file)
       @@logger.debug('Uploading ' + file_name + ' to ' + dropbox_path + '/' + file_name)
-      dropbox_client.upload dropbox_path + '/' + file_name, content, mode: :overwrite
+      File.open(file) do |io|
+        dropbox_client.upload dropbox_path + '/' + file_name, io, mode: :overwrite
+      end
     end
 
     def upload_directory(dropbox_client, directory_path, dropbox_path)

--- a/lib/dropbox-deployment.rb
+++ b/lib/dropbox-deployment.rb
@@ -40,26 +40,29 @@ module DropboxDeployment
       end
     end
 
-    def deploy
-      # Validation
-      unless File.file?('dropbox-deployment.yml')
-        puts "\nNo config file found. You need a file called `dropbox-deployment.yml` with the configuration. See the README for details\n\n"
-        exit(1)
+    def deploy(options = {})
+      config = {}
+
+      if File.file?('dropbox-deployment.yml')
+        config = YAML.load_file('dropbox-deployment.yml')
+        unless config.has_key?('deploy')
+          puts "\nError in config file! Build file must contain a `deploy` object.\n\n"
+          exit(1)
+        end
+
+        options = config["deploy"].merge(options)
       end
-      config = YAML.load_file('dropbox-deployment.yml')
-      unless config.has_key?('deploy')
-        puts "\nError in config file! Build file must contain a `deploy` object.\n\n"
-        exit(1)
-      end
-      artifact_path = config['deploy']['artifacts_path']
-      dropbox_path = config['deploy']['dropbox_path']
+
+      artifact_path = options.fetch('artifacts_path')
+      dropbox_path = options.fetch('dropbox_path')
+
 
       if ENV['DROPBOX_OAUTH_BEARER'].nil?
         puts "\nYou must have an environment variable of `DROPBOX_OAUTH_BEARER` in order to deploy to Dropbox\n\n"
         exit(1)
       end
 
-      if config['deploy']['debug']
+      if options['debug']
         @@logger.level = Logger::DEBUG
         @@logger.debug('We are in debug mode')
       end


### PR DESCRIPTION
I quickly hacked in command line arguments for dropbox_path, artifacts_path, and debug mode.  Options specified on the command line override those defined in the (now no longer required) dropbox-deployment.yml file.